### PR TITLE
feat: add global layout skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+build
+*.log

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import GlobalLayout from './layout/GlobalLayout';
+
+export default function App() {
+  return (
+    <GlobalLayout>
+      <p>Welcome to the RFID Asset Management System.</p>
+    </GlobalLayout>
+  );
+}

--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export interface BreadcrumbProps {
+  paths: string[];
+}
+
+export function Breadcrumbs({ paths }: BreadcrumbProps) {
+  return (
+    <nav className="breadcrumbs" aria-label="breadcrumb">
+      {paths.join(' / ')}
+    </nav>
+  );
+}
+
+export default Breadcrumbs;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+const items = ['Dashboard', 'Master Data', 'Transactions', 'Lookup', 'System'];
+
+export function Sidebar() {
+  return (
+    <aside className="sidebar">
+      <nav>
+        <ul>
+          {items.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      </nav>
+    </aside>
+  );
+}
+
+export default Sidebar;

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,0 +1,29 @@
+import React, { useState, useEffect } from 'react';
+
+export function TopBar() {
+  const [lang, setLang] = useState<'VI' | 'EN'>('EN');
+  const [theme, setTheme] = useState<'light' | 'dark'>('light');
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+  }, [theme]);
+
+  return (
+    <header className="topbar">
+      <input
+        type="text"
+        placeholder="Search EPC/Barcode"
+        aria-label="search"
+      />
+      <div>
+        <button onClick={() => setLang(lang === 'EN' ? 'VI' : 'EN')}>{lang}</button>
+        <button onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}>
+          {theme === 'light' ? 'Dark' : 'Light'}
+        </button>
+        <span>User</span>
+      </div>
+    </header>
+  );
+}
+
+export default TopBar;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,64 @@
+:root {
+  --bg: #ffffff;
+  --text: #000000;
+  --sidebar-bg: #f0f0f0;
+}
+
+.dark {
+  --bg: #1a1a1a;
+  --text: #ffffff;
+  --sidebar-bg: #333333;
+}
+
+body {
+  margin: 0;
+  background-color: var(--bg);
+  color: var(--text);
+  font-family: sans-serif;
+}
+
+.app {
+  display: flex;
+  min-height: 100vh;
+}
+
+.sidebar {
+  width: 200px;
+  background-color: var(--sidebar-bg);
+  padding: 1rem;
+}
+
+.sidebar ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.sidebar li {
+  margin-bottom: 0.5rem;
+}
+
+.main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid #ddd;
+}
+
+.breadcrumbs {
+  padding: 0.5rem 1rem;
+  font-size: 0.9rem;
+  border-bottom: 1px solid #ddd;
+}
+
+.content {
+  flex: 1;
+  padding: 1rem;
+}

--- a/src/layout/GlobalLayout.tsx
+++ b/src/layout/GlobalLayout.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import Sidebar from '../components/Sidebar';
+import TopBar from '../components/TopBar';
+import Breadcrumbs from '../components/Breadcrumbs';
+
+export interface GlobalLayoutProps {
+  children: React.ReactNode;
+}
+
+export function GlobalLayout({ children }: GlobalLayoutProps) {
+  return (
+    <div className="app">
+      <Sidebar />
+      <div className="main">
+        <TopBar />
+        <Breadcrumbs paths={["Home", "Detail"]} />
+        <main className="content">{children}</main>
+      </div>
+    </div>
+  );
+}
+
+export default GlobalLayout;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- set up React TypeScript scaffold for RFID Asset Management System
- add global layout with sidebar navigation, top bar, and breadcrumbs
- include light/dark theme toggle and basic responsive styles

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b172a1c590832588673ad7236fa8c5