### PR TITLE
feat: add global layout skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+build
+*.log

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import GlobalLayout from './layout/GlobalLayout';
+import GoodsReceiptList from './pages/GoodsReceiptList';
+
+export default function App() {
+  return (
+    <GlobalLayout breadcrumbs={["Transactions", "Goods Receipts"]}>
+      <GoodsReceiptList />
+    </GlobalLayout>
+  );
+}

--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export interface BreadcrumbProps {
+  paths: string[];
+}
+
+export function Breadcrumbs({ paths }: BreadcrumbProps) {
+  return (
+    <nav className="breadcrumbs" aria-label="breadcrumb">
+      {paths.join(' / ')}
+    </nav>
+  );
+}
+
+export default Breadcrumbs;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+const items = [
+  'Dashboard',
+  'Master Data',
+  'Transactions',
+  'Lookup',
+  'System',
+];
+
+export function Sidebar() {
+  return (
+    <aside className="sidebar">
+      <nav>
+        <ul>
+          {items.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      </nav>
+    </aside>
+  );
+}
+
+export default Sidebar;

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,0 +1,29 @@
+import React, { useState, useEffect } from 'react';
+
+export function TopBar() {
+  const [lang, setLang] = useState<'VI' | 'EN'>('EN');
+  const [theme, setTheme] = useState<'light' | 'dark'>('light');
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+  }, [theme]);
+
+  return (
+    <header className="topbar">
+      <input
+        type="text"
+        placeholder="Search EPC/Barcode"
+        aria-label="search"
+      />
+      <div>
+        <button onClick={() => setLang(lang === 'EN' ? 'VI' : 'EN')}>{lang}</button>
+        <button onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}>
+          {theme === 'light' ? 'Dark' : 'Light'}
+        </button>
+        <span>User</span>
+      </div>
+    </header>
+  );
+}
+
+export default TopBar;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,99 @@
+:root {
+  --bg: #ffffff;
+  --text: #000000;
+  --sidebar-bg: #f0f0f0;
+}
+
+.dark {
+  --bg: #1a1a1a;
+  --text: #ffffff;
+  --sidebar-bg: #333333;
+}
+
+body {
+  margin: 0;
+  background-color: var(--bg);
+  color: var(--text);
+  font-family: sans-serif;
+}
+
+.app {
+  display: flex;
+  min-height: 100vh;
+}
+
+.sidebar {
+  width: 200px;
+  background-color: var(--sidebar-bg);
+  padding: 1rem;
+}
+
+.sidebar ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.sidebar li {
+  margin-bottom: 0.5rem;
+}
+
+.main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid #ddd;
+}
+
+.breadcrumbs {
+  padding: 0.5rem 1rem;
+  font-size: 0.9rem;
+  border-bottom: 1px solid #ddd;
+}
+
+.content {
+  flex: 1;
+  padding: 1rem;
+}
+
+/* Goods Receipt List */
+.filters {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.filters input,
+.filters select {
+  padding: 0.25rem 0.5rem;
+}
+
+table.receipts {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+table.receipts th,
+table.receipts td {
+  padding: 0.5rem;
+  border: 1px solid #ddd;
+  text-align: left;
+}
+
+table.receipts tbody tr:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+}
+
+.empty {
+  padding: 2rem;
+  text-align: center;
+  background: #fafafa;
+  border: 1px dashed #ccc;
+}

--- a/src/layout/GlobalLayout.tsx
+++ b/src/layout/GlobalLayout.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import Sidebar from '../components/Sidebar';
+import TopBar from '../components/TopBar';
+import Breadcrumbs from '../components/Breadcrumbs';
+
+export interface GlobalLayoutProps {
+  children: React.ReactNode;
+  breadcrumbs?: string[];
+}
+
+export function GlobalLayout({ children, breadcrumbs = [] }: GlobalLayoutProps) {
+  return (
+    <div className="app">
+      <Sidebar />
+      <div className="main">
+        <TopBar />
+        {breadcrumbs.length > 0 && <Breadcrumbs paths={breadcrumbs} />}
+        <main className="content">{children}</main>
+      </div>
+    </div>
+  );
+}
+
+export default GlobalLayout;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/pages/GoodsReceiptList.tsx
+++ b/src/pages/GoodsReceiptList.tsx
@@ -1,0 +1,104 @@
+import React, { useMemo, useState } from 'react';
+
+interface Receipt {
+  code: string;
+  date: string; // ISO
+  location: string;
+  source: string;
+  createdBy: string;
+  status: 'Draft' | 'Submitted' | 'Pending Approval' | 'Posted' | 'Cancelled';
+}
+
+const sampleData: Receipt[] = [
+  {
+    code: 'GR001',
+    date: '2025-08-20',
+    location: 'Warehouse A',
+    source: 'Supplier X',
+    createdBy: 'Alice',
+    status: 'Draft',
+  },
+  {
+    code: 'GR002',
+    date: '2025-08-21',
+    location: 'Warehouse B',
+    source: 'Supplier Y',
+    createdBy: 'Bob',
+    status: 'Posted',
+  },
+];
+
+export default function GoodsReceiptList() {
+  const [search, setSearch] = useState('');
+  const [status, setStatus] = useState('');
+
+  const data = useMemo(() => {
+    return sampleData.filter((r) => {
+      const matchSearch =
+        r.code.toLowerCase().includes(search.toLowerCase()) ||
+        r.source.toLowerCase().includes(search.toLowerCase());
+      const matchStatus = status ? r.status === status : true;
+      return matchSearch && matchStatus;
+    });
+  }, [search, status]);
+
+  return (
+    <div>
+      <h1>Goods Receipts</h1>
+      <div className="filters">
+        <input
+          placeholder="Search code or source"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <select value={status} onChange={(e) => setStatus(e.target.value)}>
+          <option value="">All Status</option>
+          <option>Draft</option>
+          <option>Submitted</option>
+          <option>Pending Approval</option>
+          <option>Posted</option>
+          <option>Cancelled</option>
+        </select>
+        <button>Create Receipt</button>
+        <button>Export Excel</button>
+      </div>
+      {data.length === 0 ? (
+        <div className="empty">No receipts. <button>Create Receipt</button></div>
+      ) : (
+        <table className="receipts">
+          <thead>
+            <tr>
+              <th>Receipt Code</th>
+              <th>Date</th>
+              <th>Receiving Location</th>
+              <th>Source/Supplier</th>
+              <th>Created By</th>
+              <th>Status</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((r) => (
+              <tr key={r.code}>
+                <td>{r.code}</td>
+                <td>{r.date}</td>
+                <td>{r.location}</td>
+                <td>{r.source}</td>
+                <td>{r.createdBy}</td>
+                <td>{r.status}</td>
+                <td>
+                  <button>View</button>
+                  {(r.status === 'Draft' || r.status === 'Submitted') && (
+                    <button>Edit</button>
+                  )}
+                  {r.status === 'Draft' && <button>Delete</button>}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- set up React TypeScript scaffold for RFID Asset Management System
- add global layout with sidebar navigation, top bar, and breadcrumbs
- implement basic Goods Receipt list screen with filters and actions

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b172a1c590832588673ad7236fa8c5